### PR TITLE
Delete obstructive code

### DIFF
--- a/protoc-gen-nrpc/tmpl.go
+++ b/protoc-gen-nrpc/tmpl.go
@@ -136,7 +136,7 @@ func (h *{{.GetName}}Handler) Handler(msg *nats.Msg) {
 {{- end}}
 			if err != nil {
 				log.Printf("{{.GetName}}Handler: {{.GetName}} handler failed: %v", err)
-				errstr = "handler error: " + err.Error()
+				errstr = err.Error()
 {{- if Prometheus}}
 				serverRequestsFor{{$serviceName}}.WithLabelValues("{{.GetName}}",
 					"handler_fail").Inc()


### PR DESCRIPTION
Hey, thank you for impressive library, we using it in a work :)

Why we shouldn't have to use an additional message in error:
- We would like to use custom error types in returned error but currently we can't do it because nRPC adds an own string to error.