### PR TITLE
Improve test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+examples/helloworld/greeter_client/greeter_client
+examples/helloworld/greeter_server/greeter_server

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ go:
 before_install:
   - curl -sSL https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip -o protoc.zip
   - sudo unzip -d /usr protoc.zip bin/protoc
+  - sudo chmod a+x /usr/bin/protoc
   - go get -u github.com/golang/protobuf/protoc-gen-go

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ language: go
 go:
   - 1.7
   - 1.8
+
+before_install:
+  - curl -sSL https://github.com/google/protobuf/releases/download/v3.4.0/protoc-3.4.0-linux-x86_64.zip -o protoc.zip
+  - sudo unzip -d /usr protoc.zip bin/protoc
+  - go get -u github.com/golang/protobuf/protoc-gen-go

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,3 @@ language: go
 go:
   - 1.7
   - 1.8
-
-before_install:
-  - go get github.com/nats-io/gnatsd
-  - $GOPATH/bin/gnatsd -l /dev/null &
-

--- a/examples/helloworld/greeter_server/testrunner_test.go
+++ b/examples/helloworld/greeter_server/testrunner_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nats-io/gnatsd/logger"
+	natsServer "github.com/nats-io/gnatsd/server"
+)
+
+func TestMain(m *testing.M) {
+	gnatsd := natsServer.New(&natsServer.Options{})
+	gnatsd.SetLogger(
+		logger.NewStdLogger(false, false, false, false, false),
+		false, false)
+	go gnatsd.Start()
+	defer gnatsd.Shutdown()
+
+	if !gnatsd.ReadyForConnections(time.Second) {
+		log.Fatal("Cannot start the gnatsd server")
+	}
+
+	os.Exit(m.Run())
+}

--- a/helloworld_test.go
+++ b/helloworld_test.go
@@ -1,0 +1,63 @@
+package nrpc
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestHelloWorldExample(t *testing.T) {
+	// make sure protoc-gen-nrpc is up to date
+	installGenRPC := exec.Command("go", "install", "./protoc-gen-nrpc")
+	if err := installGenRPC.Run(); err != nil {
+		t.Fatal("Install protoc-gen-nrpc failed", err)
+	}
+	// generate the sources
+	generate := exec.Command("go", "generate", "./examples/helloworld/helloworld")
+	if err := generate.Run(); err != nil {
+		t.Fatal("Generate failed", err)
+	}
+	// build
+	buildServer := exec.Command("go", "build",
+		"-o", "./examples/helloworld/greeter_server/greeter_server",
+		"./examples/helloworld/greeter_server")
+	if out, err := buildServer.CombinedOutput(); err != nil {
+		t.Fatal("Buid server failed", err, string(out))
+	}
+	buildClient := exec.Command("go", "build",
+		"-o", "./examples/helloworld/greeter_client/greeter_client",
+		"./examples/helloworld/greeter_client")
+	if out, err := buildClient.CombinedOutput(); err != nil {
+		t.Fatal("Buid client failed", err, string(out))
+	}
+	// run the server
+	server := exec.Command("./examples/helloworld/greeter_server/greeter_server")
+	var serverStdout bytes.Buffer
+	server.Stdout = &serverStdout
+	server.Start()
+	defer func() {
+		if server.Process != nil {
+			server.Process.Signal(os.Interrupt)
+		}
+		if err := server.Wait(); err != nil {
+			t.Error("Server run failed:", err)
+			t.Error("Server output:", serverStdout.String())
+		}
+	}()
+
+	// run the client and check its output
+	client := exec.Command("./examples/helloworld/greeter_client/greeter_client")
+	timeout := time.AfterFunc(time.Second, func() { client.Process.Kill() })
+	out, err := client.CombinedOutput()
+	timeout.Stop()
+	if err != nil {
+		t.Fatal("Run client failed with:", err)
+	}
+	expectedOuput := "Greeting: Hello world\n"
+	if string(out) != expectedOuput {
+		t.Errorf("Wrong client output. Expected '%s', got '%s'",
+			expectedOuput, string(out))
+	}
+}

--- a/helloworld_test.go
+++ b/helloworld_test.go
@@ -11,13 +11,13 @@ import (
 func TestHelloWorldExample(t *testing.T) {
 	// make sure protoc-gen-nrpc is up to date
 	installGenRPC := exec.Command("go", "install", "./protoc-gen-nrpc")
-	if err := installGenRPC.Run(); err != nil {
-		t.Fatal("Install protoc-gen-nrpc failed", err)
+	if out, err := installGenRPC.CombinedOutput(); err != nil {
+		t.Fatal("Install protoc-gen-nrpc failed", err, ":\n", string(out))
 	}
 	// generate the sources
 	generate := exec.Command("go", "generate", "./examples/helloworld/helloworld")
-	if err := generate.Run(); err != nil {
-		t.Fatal("Generate failed", err)
+	if out, err := generate.CombinedOutput(); err != nil {
+		t.Fatal("Generate failed", err, ":\n", string(out))
 	}
 	// build
 	buildServer := exec.Command("go", "build",
@@ -53,7 +53,7 @@ func TestHelloWorldExample(t *testing.T) {
 	out, err := client.CombinedOutput()
 	timeout.Stop()
 	if err != nil {
-		t.Fatal("Run client failed with:", err)
+		t.Fatal("Run client failed with:", err, ", output was:\n", string(out))
 	}
 	expectedOuput := "Greeting: Hello world\n"
 	if string(out) != expectedOuput {

--- a/testrunner_test.go
+++ b/testrunner_test.go
@@ -1,0 +1,26 @@
+package nrpc
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/nats-io/gnatsd/logger"
+	"github.com/nats-io/gnatsd/server"
+)
+
+func TestMain(m *testing.M) {
+	gnatsd := server.New(&server.Options{})
+	gnatsd.SetLogger(
+		logger.NewStdLogger(false, false, false, false, false),
+		false, false)
+	go gnatsd.Start()
+	defer gnatsd.Shutdown()
+
+	if !gnatsd.ReadyForConnections(time.Second) {
+		log.Fatal("Cannot start the gnatsd server")
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This PR sits on top of #15.

Running the tests and make sure the examples runs properly requires many commands, including running a gnatsd, and I often forget a step.

To avoid any mistake, I completed the tests so that:
- gnatsd is start&stop by the test runner
- a new test run all the necessary commands for ensuring that the helloworld example works properly.

Now a simple "go test ." should be enough to make sure everything is ok.

Note that the metric_helloworld is untouched by the test suite, it still needs to be re-generated manually.