### PR TITLE
Use an interface for nats.Conn

### DIFF
--- a/examples/alloptions/alloptions.nrpc.go
+++ b/examples/alloptions/alloptions.nrpc.go
@@ -22,11 +22,11 @@ type SvcCustomSubjectServer interface {
 // subscription using a given SvcCustomSubjectServer implementation.
 type SvcCustomSubjectHandler struct {
 	ctx    context.Context
-	nc     *nats.Conn
+	nc     nrpc.NatsConn
 	server SvcCustomSubjectServer
 }
 
-func NewSvcCustomSubjectHandler(ctx context.Context, nc *nats.Conn, s SvcCustomSubjectServer) *SvcCustomSubjectHandler {
+func NewSvcCustomSubjectHandler(ctx context.Context, nc nrpc.NatsConn, s SvcCustomSubjectServer) *SvcCustomSubjectHandler {
 	return &SvcCustomSubjectHandler{
 		ctx:    ctx,
 		nc:     nc,
@@ -111,7 +111,7 @@ func (h *SvcCustomSubjectHandler) Handler(msg *nats.Msg) {
 }
 
 type SvcCustomSubjectClient struct {
-	nc      *nats.Conn
+	nc      nrpc.NatsConn
 	PkgSubject string
 	PkgParaminstance string
 	Subject string
@@ -119,7 +119,7 @@ type SvcCustomSubjectClient struct {
 	Timeout time.Duration
 }
 
-func NewSvcCustomSubjectClient(nc *nats.Conn, pkgParaminstance string) *SvcCustomSubjectClient {
+func NewSvcCustomSubjectClient(nc nrpc.NatsConn, pkgParaminstance string) *SvcCustomSubjectClient {
 	return &SvcCustomSubjectClient{
 		nc:      nc,
 		PkgSubject: "root",
@@ -168,11 +168,11 @@ type SvcSubjectParamsServer interface {
 // subscription using a given SvcSubjectParamsServer implementation.
 type SvcSubjectParamsHandler struct {
 	ctx    context.Context
-	nc     *nats.Conn
+	nc     nrpc.NatsConn
 	server SvcSubjectParamsServer
 }
 
-func NewSvcSubjectParamsHandler(ctx context.Context, nc *nats.Conn, s SvcSubjectParamsServer) *SvcSubjectParamsHandler {
+func NewSvcSubjectParamsHandler(ctx context.Context, nc nrpc.NatsConn, s SvcSubjectParamsServer) *SvcSubjectParamsHandler {
 	return &SvcSubjectParamsHandler{
 		ctx:    ctx,
 		nc:     nc,
@@ -237,7 +237,7 @@ func (h *SvcSubjectParamsHandler) Handler(msg *nats.Msg) {
 }
 
 type SvcSubjectParamsClient struct {
-	nc      *nats.Conn
+	nc      nrpc.NatsConn
 	PkgSubject string
 	PkgParaminstance string
 	Subject string
@@ -246,7 +246,7 @@ type SvcSubjectParamsClient struct {
 	Timeout time.Duration
 }
 
-func NewSvcSubjectParamsClient(nc *nats.Conn, pkgParaminstance string, svcParamclientid string) *SvcSubjectParamsClient {
+func NewSvcSubjectParamsClient(nc nrpc.NatsConn, pkgParaminstance string, svcParamclientid string) *SvcSubjectParamsClient {
 	return &SvcSubjectParamsClient{
 		nc:      nc,
 		PkgSubject: "root",

--- a/examples/helloworld/helloworld/helloworld.nrpc.go
+++ b/examples/helloworld/helloworld/helloworld.nrpc.go
@@ -21,11 +21,11 @@ type GreeterServer interface {
 // subscription using a given GreeterServer implementation.
 type GreeterHandler struct {
 	ctx    context.Context
-	nc     *nats.Conn
+	nc     nrpc.NatsConn
 	server GreeterServer
 }
 
-func NewGreeterHandler(ctx context.Context, nc *nats.Conn, s GreeterServer) *GreeterHandler {
+func NewGreeterHandler(ctx context.Context, nc nrpc.NatsConn, s GreeterServer) *GreeterHandler {
 	return &GreeterHandler{
 		ctx:    ctx,
 		nc:     nc,
@@ -88,14 +88,14 @@ func (h *GreeterHandler) Handler(msg *nats.Msg) {
 }
 
 type GreeterClient struct {
-	nc      *nats.Conn
+	nc      nrpc.NatsConn
 	PkgSubject string
 	Subject string
 	Encoding string
 	Timeout time.Duration
 }
 
-func NewGreeterClient(nc *nats.Conn) *GreeterClient {
+func NewGreeterClient(nc nrpc.NatsConn) *GreeterClient {
 	return &GreeterClient{
 		nc:      nc,
 		PkgSubject: "helloworld",

--- a/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
+++ b/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
@@ -70,11 +70,11 @@ var (
 // subscription using a given GreeterServer implementation.
 type GreeterHandler struct {
 	ctx    context.Context
-	nc     *nats.Conn
+	nc     nrpc.NatsConn
 	server GreeterServer
 }
 
-func NewGreeterHandler(ctx context.Context, nc *nats.Conn, s GreeterServer) *GreeterHandler {
+func NewGreeterHandler(ctx context.Context, nc nrpc.NatsConn, s GreeterServer) *GreeterHandler {
 	return &GreeterHandler{
 		ctx:    ctx,
 		nc:     nc,
@@ -149,14 +149,14 @@ func (h *GreeterHandler) Handler(msg *nats.Msg) {
 }
 
 type GreeterClient struct {
-	nc      *nats.Conn
+	nc      nrpc.NatsConn
 	PkgSubject string
 	Subject string
 	Encoding string
 	Timeout time.Duration
 }
 
-func NewGreeterClient(nc *nats.Conn) *GreeterClient {
+func NewGreeterClient(nc nrpc.NatsConn) *GreeterClient {
 	return &GreeterClient{
 		nc:      nc,
 		PkgSubject: "helloworld",

--- a/nrpc.go
+++ b/nrpc.go
@@ -20,6 +20,11 @@ type Reply interface {
 	GetError() *Error
 }
 
+type NatsConn interface {
+	Request(subj string, data []byte, timeout time.Duration) (*nats.Msg, error)
+	Publish(subj string, data []byte) error
+}
+
 func (e *Error) Error() string {
 	return fmt.Sprintf("%s error: %s", Error_Type_name[int32(e.Type)], e.Message)
 }
@@ -104,7 +109,7 @@ func ParseSubject(
 	return
 }
 
-func Call(req proto.Message, rep proto.Message, nc *nats.Conn, subject string, encoding string, timeout time.Duration) error {
+func Call(req proto.Message, rep proto.Message, nc NatsConn, subject string, encoding string, timeout time.Duration) error {
 	// encode request
 	rawRequest, err := Marshal(encoding, req)
 	if err != nil {
@@ -152,7 +157,7 @@ func Call(req proto.Message, rep proto.Message, nc *nats.Conn, subject string, e
 	return nil
 }
 
-func Publish(resp proto.Message, withError *Error, nc *nats.Conn, subject string, encoding string) error {
+func Publish(resp proto.Message, withError *Error, nc NatsConn, subject string, encoding string) error {
 	if _, ok := resp.(Reply); !ok {
 		// wrap the response in a RPCResponse
 		if withError == nil { // send any inner object only if error is unset

--- a/protoc-gen-nrpc/tmpl.go
+++ b/protoc-gen-nrpc/tmpl.go
@@ -86,11 +86,11 @@ var (
 // subscription using a given {{.GetName}}Server implementation.
 type {{.GetName}}Handler struct {
 	ctx    context.Context
-	nc     *nats.Conn
+	nc     nrpc.NatsConn
 	server {{.GetName}}Server
 }
 
-func New{{.GetName}}Handler(ctx context.Context, nc *nats.Conn, s {{.GetName}}Server) *{{.GetName}}Handler {
+func New{{.GetName}}Handler(ctx context.Context, nc nrpc.NatsConn, s {{.GetName}}Server) *{{.GetName}}Handler {
 	return &{{.GetName}}Handler{
 		ctx:    ctx,
 		nc:     nc,
@@ -216,7 +216,7 @@ func (h *{{.GetName}}Handler) Handler(msg *nats.Msg) {
 }
 
 type {{.GetName}}Client struct {
-	nc      *nats.Conn
+	nc      nrpc.NatsConn
 	{{- if ne 0 (len $pkgSubject)}}
 	PkgSubject string
 	{{- end}}
@@ -231,7 +231,7 @@ type {{.GetName}}Client struct {
 	Timeout time.Duration
 }
 
-func New{{.GetName}}Client(nc *nats.Conn
+func New{{.GetName}}Client(nc nrpc.NatsConn
 	{{- range $pkgSubjectParams -}}
 	, pkgParam{{.}} string
 	{{- end -}}


### PR DESCRIPTION
Aside from allowing server-less tests for functions taking a nats conn, it
makes it possible to provide custom implementations of nats conn.