### PR TITLE
Generates a client that regroups all the service clients

### DIFF
--- a/examples/alloptions/alloptions.nrpc.go
+++ b/examples/alloptions/alloptions.nrpc.go
@@ -669,3 +669,16 @@ func (c *Client) SetSvcSubjectParamsParams(
 	c.SvcSubjectParams.Encoding = c.defaultEncoding
 	c.SvcSubjectParams.Timeout = c.defaultTimeout
 }
+
+func (c *Client) NewSvcSubjectParams(
+	clientid string,
+) *SvcSubjectParamsClient {
+	client := NewSvcSubjectParamsClient(
+		c.nc,
+		c.pkgParaminstance,
+		clientid,
+	)
+	client.Encoding = c.defaultEncoding
+	client.Timeout = c.defaultTimeout
+	return client
+}

--- a/examples/alloptions/alloptions.nrpc.go
+++ b/examples/alloptions/alloptions.nrpc.go
@@ -607,3 +607,65 @@ func (c *NoRequestServiceClient) MtNoRequestSubscribeChan(
 	return ch, sub, err
 }
 
+
+type Client struct {
+	nc      nrpc.NatsConn
+	defaultEncoding string
+	defaultTimeout time.Duration
+	pkgSubject string
+	pkgParaminstance string
+	SvcCustomSubject *SvcCustomSubjectClient
+	SvcSubjectParams *SvcSubjectParamsClient
+	NoRequestService *NoRequestServiceClient
+}
+
+func NewClient(nc nrpc.NatsConn, pkgParaminstance string) *Client {
+	c := Client{
+		nc: nc,
+		defaultEncoding: "protobuf",
+		defaultTimeout: 5*time.Second,
+		pkgSubject: "root",
+		pkgParaminstance: pkgParaminstance,
+	};
+	c.SvcCustomSubject = NewSvcCustomSubjectClient(nc, c.pkgParaminstance)
+	c.NoRequestService = NewNoRequestServiceClient(nc, c.pkgParaminstance)
+	return &c
+}
+
+func (c *Client) SetEncoding(encoding string) {
+	c.defaultEncoding = encoding
+	if c.SvcCustomSubject != nil {
+		c.SvcCustomSubject.Encoding = encoding
+	}
+	if c.SvcSubjectParams != nil {
+		c.SvcSubjectParams.Encoding = encoding
+	}
+	if c.NoRequestService != nil {
+		c.NoRequestService.Encoding = encoding
+	}
+}
+
+func (c *Client) SetTimeout(t time.Duration) {
+	c.defaultTimeout = t
+	if c.SvcCustomSubject != nil {
+		c.SvcCustomSubject.Timeout = t
+	}
+	if c.SvcSubjectParams != nil {
+		c.SvcSubjectParams.Timeout = t
+	}
+	if c.NoRequestService != nil {
+		c.NoRequestService.Timeout = t
+	}
+}
+
+func (c *Client) SetSvcSubjectParamsParams(
+	clientid string,
+) {
+	c.SvcSubjectParams = NewSvcSubjectParamsClient(
+		c.nc,
+		c.pkgParaminstance,
+		clientid,
+	)
+	c.SvcSubjectParams.Encoding = c.defaultEncoding
+	c.SvcSubjectParams.Timeout = c.defaultTimeout
+}

--- a/examples/helloworld/helloworld/helloworld.nrpc.go
+++ b/examples/helloworld/helloworld/helloworld.nrpc.go
@@ -130,3 +130,35 @@ func (c *GreeterClient) SayHello(req HelloRequest) (resp HelloReply, err error) 
 
 	return
 }
+type Client struct {
+	nc      nrpc.NatsConn
+	defaultEncoding string
+	defaultTimeout time.Duration
+	pkgSubject string
+	Greeter *GreeterClient
+}
+
+func NewClient(nc nrpc.NatsConn) *Client {
+	c := Client{
+		nc: nc,
+		defaultEncoding: "protobuf",
+		defaultTimeout: 5*time.Second,
+		pkgSubject: "helloworld",
+	};
+	c.Greeter = NewGreeterClient(nc)
+	return &c
+}
+
+func (c *Client) SetEncoding(encoding string) {
+	c.defaultEncoding = encoding
+	if c.Greeter != nil {
+		c.Greeter.Encoding = encoding
+	}
+}
+
+func (c *Client) SetTimeout(t time.Duration) {
+	c.defaultTimeout = t
+	if c.Greeter != nil {
+		c.Greeter.Timeout = t
+	}
+}

--- a/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
+++ b/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
@@ -204,6 +204,38 @@ func (c *GreeterClient) SayHello(req HelloRequest) (resp HelloReply, err error) 
 
 	return
 }
+type Client struct {
+	nc      nrpc.NatsConn
+	defaultEncoding string
+	defaultTimeout time.Duration
+	pkgSubject string
+	Greeter *GreeterClient
+}
+
+func NewClient(nc nrpc.NatsConn) *Client {
+	c := Client{
+		nc: nc,
+		defaultEncoding: "protobuf",
+		defaultTimeout: 5*time.Second,
+		pkgSubject: "helloworld",
+	};
+	c.Greeter = NewGreeterClient(nc)
+	return &c
+}
+
+func (c *Client) SetEncoding(encoding string) {
+	c.defaultEncoding = encoding
+	if c.Greeter != nil {
+		c.Greeter.Encoding = encoding
+	}
+}
+
+func (c *Client) SetTimeout(t time.Duration) {
+	c.defaultTimeout = t
+	if c.Greeter != nil {
+		c.Greeter.Timeout = t
+	}
+}
 
 func init() {
 	// register metrics for service Greeter

--- a/protoc-gen-nrpc/tmpl.go
+++ b/protoc-gen-nrpc/tmpl.go
@@ -529,6 +529,25 @@ func (c *Client) Set{{.GetName}}Params(
 	c.{{.GetName}}.Encoding = c.defaultEncoding
 	c.{{.GetName}}.Timeout = c.defaultTimeout
 }
+
+func (c *Client) New{{.GetName}}(
+	{{- range GetServiceSubjectParams .}}
+	{{ . }} string,
+	{{- end}}
+) *{{.GetName}}Client {
+	client := New{{.GetName}}Client(
+		c.nc,
+	{{- range $pkgSubjectParams}}
+		c.pkgParam{{ . }},
+	{{- end}}
+	{{- range GetServiceSubjectParams .}}
+		{{ . }},
+	{{- end}}
+	)
+	client.Encoding = c.defaultEncoding
+	client.Timeout = c.defaultTimeout
+	return client
+}
 {{- end}}
 {{- end}}
 


### PR DESCRIPTION
If a client program needs to use all the services of a package, it can become
tedious to setup and keep a hold on each service client.

This patch generates a package-level client that regroup all the service client in
a single struct, with some helpers to set all the timeouts or encoding.
It also holds the services parameters.