### PR TITLE
[prometheus] Fix the summary helps

### DIFF
--- a/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
+++ b/examples/metrics_helloworld/helloworld/helloworld.nrpc.go
@@ -23,7 +23,7 @@ var (
 	clientRCTForGreeter = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "nrpc_client_request_completion_time_seconds",
-			Help:       "The request completion time for Greeter calls, measured client-side.",
+			Help:       "The request completion time for calls, measured client-side.",
 			Objectives: map[float64]float64{0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			ConstLabels: map[string]string{
 				"service": "Greeter",
@@ -35,7 +35,7 @@ var (
 	serverHETForGreeter = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "nrpc_server_handler_execution_time_seconds",
-			Help:       "The handler execution time for Greeter calls, measured server-side.",
+			Help:       "The handler execution time for calls, measured server-side.",
 			Objectives: map[float64]float64{0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			ConstLabels: map[string]string{
 				"service": "Greeter",

--- a/protoc-gen-nrpc/tmpl.go
+++ b/protoc-gen-nrpc/tmpl.go
@@ -53,7 +53,7 @@ var (
 	clientRCTFor{{.GetName}} = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "nrpc_client_request_completion_time_seconds",
-			Help:       "The request completion time for {{.GetName}} calls, measured client-side.",
+			Help:       "The request completion time for calls, measured client-side.",
 			Objectives: map[float64]float64{0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			ConstLabels: map[string]string{
 				"service": "{{.GetName}}",
@@ -65,7 +65,7 @@ var (
 	serverHETFor{{.GetName}} = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Name:       "nrpc_server_handler_execution_time_seconds",
-			Help:       "The handler execution time for {{.GetName}} calls, measured server-side.",
+			Help:       "The handler execution time for calls, measured server-side.",
 			Objectives: map[float64]float64{0.9: 0.01, 0.95: 0.01, 0.99: 0.001},
 			ConstLabels: map[string]string{
 				"service": "{{.GetName}}",


### PR DESCRIPTION
All summary with a same name must have the same help string,
so the service name cannot be included in it.